### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/packages/merge-objects/src/index.ts
+++ b/packages/merge-objects/src/index.ts
@@ -25,10 +25,11 @@ export const mergeObjects = (item: Item, otherItem: Item): Item => {
 
   return filterArray([...Object.keys(item), ...Object.keys(otherItem)]).reduce(
     (acc: Record<string, unknown>, key: string) => {
+      
       if (typeof acc[key] === 'undefined') {
         acc[key] = otherItem[key]
       } else if (isObject(acc[key]) || isArray(acc[key])) {
-        acc[key] = mergeObjects(item[key], otherItem[key])
+        acc[key] = !isPrototypePolluted(key) && mergeObjects(item[key], otherItem[key])
       } else if (acc[key] !== otherItem[key] && typeof otherItem[key] !== 'undefined') {
         acc[key] = otherItem[key]
       }
@@ -37,5 +38,7 @@ export const mergeObjects = (item: Item, otherItem: Item): Item => {
     item,
   )
 }
+
+const isPrototypePolluted = (key: string) => ['__proto__', 'constructor', 'prototype'].includes(key)
 
 export default mergeObjects


### PR DESCRIPTION
### :bar_chart: Metadata *

`@common-utilities/merge-objects ` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40common-utilities%2Fmerge-objects

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var a = require("@common-utilities/merge-objects")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
a.mergeObjects(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @common-utilities/merge-objects # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102844367-4e23fe00-4431-11eb-95fe-3d2712c14472.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
